### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-## Logos Innovation Lab is a design and R&D studio working on innovating web3 products. It is part of the Logos ecosystem. 
+## Logos Innovation Lab was a design and R&D studio that worked on innovating web3 products and was part of the Logos ecosystem. The programme has been sunset, but we leave the repo up for transparency and reference. 
 
 Logos is a continuation of the original cypherpunk movement, advocating the widespread use of strong cryptography and privacy-enhancing technologies as a route to social and political change.
 


### PR DESCRIPTION
Logos communications department was asked to remove or amend references to Logos Innovation Lab to reflect its discontinuation. 

In addition to the changes suggested here, we might change the main repo title to:

"Logos Lab (Discontinued)" 

and change the repo description to: 

"Logos Innovation Lab was a design and R&D studio that worked on innovating web3 products and was part of the Logos ecosystem."